### PR TITLE
Add fp16 support for faster inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# ignore pycache
+__pycache__/
+
+# ignore generated videos
+*.mp4
+
+# ignore .egg-info from setup tools
+*.egg-info
+

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ You cloud also use simgen with metadrive.
 python metadrive_simgen.py
 ```
 
+Flag for half-precision / float16 inference:
+```bash
+python metadrive_simgen.py -p fp16
+```
+Otherwise, default setting will be float32.
+
 ## DIVA Dataset <a name="dataset"></a>
 
 ![method](./assets/diva_real.png "DIVA dataset")

--- a/metadrive_simgen.py
+++ b/metadrive_simgen.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
 
     # ===== SimGen Setup =====
     pipeline = SimGenPipeline(torch_dtype=torch_dtype)
-    ddim_steps = 50
+    ddim_steps = 100
 
     # ===== MetaDrive Setup =====
     skip_steps = 7
@@ -205,8 +205,8 @@ if __name__ == "__main__":
             "no_traffic": False,
             "sequential_seed": True,
             "reactive_traffic": False,
-            "num_scenarios": 1,
-            "horizon": 3,
+            "num_scenarios": 9,
+            "horizon": 1000,
             "no_static_vehicles": False,
             "agent_configs": {
                 "default_agent": dict(use_special_color=True, vehicle_model="varying_dynamics_bounding_box")
@@ -269,7 +269,7 @@ if __name__ == "__main__":
         # " in a supermario style",
     ]
 
-    for ep in range(2):
+    for ep in range(9):
         frames = []
         env.reset()
         seed = np.random.randint(0, 100000)

--- a/simgen/simgen.py
+++ b/simgen/simgen.py
@@ -181,14 +181,16 @@ class SimGenPipeline(Pipeline):
             mask = torch.from_numpy(mask.copy()).cuda()
             mask = torch.stack([mask for _ in range(num_samples)], dim=0)
 
+            input_dict = dict(jpg=image, txt=anno, local_conditions=local_control, global_conditions=global_control,
+                            mask=mask, name="testing pipeline")
+
             # convert dtype using autocast
             with torch.autocast(device_type="cuda", dtype=self.dtype):
-                input_dict = dict(jpg=image, txt=anno, local_conditions=local_control, global_conditions=global_control,
-                                mask=mask, name="testing pipeline")
                 return_log = self.model.log_images(input_dict, N=num_samples, n_row=1, sample=False, ddim_steps=ddim_steps,
                                                 ddim_eta=eta, unconditional_guidance_scale=scale,
                                                 first_cond_model=self.first_cond_model, strength=strength,)
-                results = return_log[f"samples_cfg_scale_{scale:.2f}"]
+                
+            results = return_log[f"samples_cfg_scale_{scale:.2f}"]
 
 
             results = results.permute(0, 2, 3, 1).clamp(-1.0, 1.0).to(torch.float32)

--- a/simgen/simgen.py
+++ b/simgen/simgen.py
@@ -48,7 +48,6 @@ class SimGenPipeline(Pipeline):
         model = create_model(config_path).cpu()
         model.load_state_dict(load_state_dict(ckpt_path, location=device_map))
         self.model = model.cuda()
-        self.model.to(torch_dtype)
         self.dtype = torch_dtype
         self.ddim_sampler = DDIMSampler(model)
         self.split_back_ground = False
@@ -182,18 +181,14 @@ class SimGenPipeline(Pipeline):
             mask = torch.from_numpy(mask.copy()).cuda()
             mask = torch.stack([mask for _ in range(num_samples)], dim=0)
 
-            # convert dtype
-            image = image.to(self.dtype)
-            local_control = local_control.to(self.dtype)
-            global_control = global_control.to(self.dtype)
-            mask = mask.to(self.dtype)
-
-            input_dict = dict(jpg=image, txt=anno, local_conditions=local_control, global_conditions=global_control,
-                              mask=mask, name="testing pipeline")
-            return_log = self.model.log_images(input_dict, N=num_samples, n_row=1, sample=False, ddim_steps=ddim_steps,
-                                               ddim_eta=eta, unconditional_guidance_scale=scale,
-                                               first_cond_model=self.first_cond_model, strength=strength,)
-            results = return_log[f"samples_cfg_scale_{scale:.2f}"]
+            # convert dtype using autocast
+            with torch.autocast(device_type="cuda", dtype=self.dtype):
+                input_dict = dict(jpg=image, txt=anno, local_conditions=local_control, global_conditions=global_control,
+                                mask=mask, name="testing pipeline")
+                return_log = self.model.log_images(input_dict, N=num_samples, n_row=1, sample=False, ddim_steps=ddim_steps,
+                                                ddim_eta=eta, unconditional_guidance_scale=scale,
+                                                first_cond_model=self.first_cond_model, strength=strength,)
+                results = return_log[f"samples_cfg_scale_{scale:.2f}"]
 
 
             results = results.permute(0, 2, 3, 1).clamp(-1.0, 1.0).to(torch.float32)


### PR DESCRIPTION
## Usage:

Flag for half-precision / float16 inference:
```bash
python metadrive_simgen.py -p fp16
```
If not provided, the default setting will be float32.

## Comparison for inference speeds:
### **fp32:**
```
Running DDIM Sampling with 60 timesteps
Decoding image: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 60/60 [00:08<00:00,  7.23it/s]
Running DDIM Sampling with 100 timesteps
DDIM Sampler: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:20<00:00,  4.96it/s]
```
60 timesteps:  **~7 it/s, 8 seconds**
100 timesteps:  **~5 it/s, 20 seconds**


### **fp16:** 
```
Running DDIM Sampling with 60 timesteps
Decoding image: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 60/60 [00:02<00:00, 20.56it/s]
Running DDIM Sampling with 100 timesteps
DDIM Sampler: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:07<00:00, 13.69it/s]
```

60 timesteps:  **~20 it/s, 2 seconds**
100 timesteps:  **~14 it/s, 7 seconds**